### PR TITLE
Add a root dir to the zip files

### DIFF
--- a/build
+++ b/build
@@ -18,13 +18,11 @@ if __name__ == '__main__':
 	for path in paths:
 		if not os.path.isdir(path) or path.startswith('.') or os.path.join(cwd, path) == output_dir: continue
 
-		files = glob(os.path.join(cwd, path, '**/*'), recursive=True)
+		files = glob(os.path.join(path, '**/*'), recursive=True)
 
 		zip_path = os.path.join(output_dir, path + '.zip')
 		with zipfile.ZipFile(zip_path, 'w') as myzip:
 			for f in files:
-				# Get name relative to example directory.
-				name = f.split(path + os.sep)[1]
-				myzip.write(f, name, compress_type=zipfile.ZIP_DEFLATED)
+				myzip.write(f, f, compress_type=zipfile.ZIP_DEFLATED)
 
 		print('Created %s' % zip_path)


### PR DESCRIPTION
Directory name (which is also the zip name) is also used as root dir in the zip.
Example: https://59b65ce50752d05175e2f60a--nerdalize-examples.netlify.com/deltares-delft3d.zip